### PR TITLE
fix: resolve default template instead of hardcoded DEFAULT_TEMPLATE_ID

### DIFF
--- a/workers/api/adapters/telegram_webhook.ts
+++ b/workers/api/adapters/telegram_webhook.ts
@@ -1,10 +1,10 @@
 import { Bot, webhookCallback } from "grammy";
 import type { UserFromGetMe } from "grammy/types";
-import type { ApiEnv } from "../../shared/mod.ts";
+import type { ApiEnv, TemplateRepositoryPort } from "../../shared/mod.ts";
 import { D1CardRepository } from "../../shared/adapters/d1_card_repository.ts";
 import { D1SubmissionRepository } from "../../shared/adapters/d1_submission_repository.ts";
-import { D1UserRepository } from "../../shared/adapters/d1_user_repository.ts";
 import { D1TemplateRepository } from "../../shared/adapters/d1_template_repository.ts";
+import { D1UserRepository } from "../../shared/adapters/d1_user_repository.ts";
 import { createTelegramNotification } from "../../shared/adapters/telegram_notification.ts";
 import { CfQueue } from "./cf_queue.ts";
 import { parseAddCommand } from "../handlers/add_command.ts";
@@ -14,20 +14,23 @@ import { type ExportCommandDeps, handleExportCommand } from "../handlers/export_
 // Cache per isolate — immutable bot metadata, not mutable application state.
 let cachedBotInfo: UserFromGetMe | undefined;
 
-const DEFAULT_TEMPLATE_ID = 1;
+export type WebhookDeps = SubmitWordDeps & {
+  readonly templateRepo: TemplateRepositoryPort;
+};
 
 export type WebhookOptions = {
   readonly botInfo?: UserFromGetMe;
-  readonly deps?: SubmitWordDeps;
+  readonly deps?: WebhookDeps;
   readonly exportDeps?: ExportCommandDeps;
 };
 
-function buildDeps(env: ApiEnv): SubmitWordDeps {
+function buildDeps(env: ApiEnv): WebhookDeps {
   return {
     userRepo: new D1UserRepository(env.DB),
     cardRepo: new D1CardRepository(env.DB),
     submissionRepo: new D1SubmissionRepository(env.DB),
     queue: new CfQueue(env.EVENTS),
+    templateRepo: new D1TemplateRepository(env.DB),
   };
 }
 
@@ -62,7 +65,7 @@ export async function handleWebhook(
   return handler(req);
 }
 
-function registerAddCommand(bot: Bot, deps: SubmitWordDeps): void {
+function registerAddCommand(bot: Bot, deps: WebhookDeps): void {
   bot.command("add", async (ctx) => {
     const text = ctx.match;
     if (!text) {
@@ -82,6 +85,18 @@ function registerAddCommand(bot: Bot, deps: SubmitWordDeps): void {
       return;
     }
 
+    const templateResult = await deps.templateRepo.findDefault();
+    if (templateResult.isErr()) {
+      console.error({ event: "template_lookup_failed", error: templateResult.error.message, userId: from.id });
+      await ctx.reply("Something went wrong. Please try again later.");
+      return;
+    }
+    if (!templateResult.value) {
+      console.error({ event: "no_default_template", userId: from.id });
+      await ctx.reply("No active card template configured. Please contact the admin.");
+      return;
+    }
+
     const sentMsg = await ctx.reply(`⏳ Generating card for "${parsed.word}"...`);
 
     const result = await submitWord(
@@ -93,7 +108,7 @@ function registerAddCommand(bot: Bot, deps: SubmitWordDeps): void {
         sentence: parsed.sentence,
         chatId: String(ctx.chat.id),
         messageId: String(sentMsg.message_id),
-        templateId: DEFAULT_TEMPLATE_ID,
+        templateId: templateResult.value.id,
       },
       deps,
     );
@@ -134,6 +149,18 @@ function registerAddCommand(bot: Bot, deps: SubmitWordDeps): void {
       return;
     }
 
+    const templateResult = await deps.templateRepo.findDefault();
+    if (templateResult.isErr()) {
+      console.error({ event: "template_lookup_failed", error: templateResult.error.message, userId: from.id });
+      await ctx.reply("Something went wrong. Please try again later.");
+      return;
+    }
+    if (!templateResult.value) {
+      console.error({ event: "no_default_template", userId: from.id });
+      await ctx.reply("No active card template configured. Please contact the admin.");
+      return;
+    }
+
     const sentMsg = await ctx.reply(`⏳ Generating card for "${parsed.word}"...`);
 
     const result = await submitWord(
@@ -145,7 +172,7 @@ function registerAddCommand(bot: Bot, deps: SubmitWordDeps): void {
         sentence: parsed.sentence,
         chatId: String(ctx.chat.id),
         messageId: String(sentMsg.message_id),
-        templateId: DEFAULT_TEMPLATE_ID,
+        templateId: templateResult.value.id,
       },
       deps,
     );

--- a/workers/api/adapters/telegram_webhook.ts
+++ b/workers/api/adapters/telegram_webhook.ts
@@ -1,4 +1,5 @@
 import { Bot, webhookCallback } from "grammy";
+import type { Transformer } from "grammy";
 import type { UserFromGetMe } from "grammy/types";
 import type { ApiEnv, TemplateRepositoryPort } from "../../shared/mod.ts";
 import { D1CardRepository } from "../../shared/adapters/d1_card_repository.ts";
@@ -9,6 +10,7 @@ import { createTelegramNotification } from "../../shared/adapters/telegram_notif
 import { CfQueue } from "./cf_queue.ts";
 import { parseAddCommand } from "../handlers/add_command.ts";
 import { submitWord, type SubmitWordDeps } from "../services/submit_word.ts";
+import { resolveTemplate } from "../services/resolve_template.ts";
 import { type ExportCommandDeps, handleExportCommand } from "../handlers/export_command.ts";
 
 // Cache per isolate — immutable bot metadata, not mutable application state.
@@ -22,6 +24,7 @@ export type WebhookOptions = {
   readonly botInfo?: UserFromGetMe;
   readonly deps?: WebhookDeps;
   readonly exportDeps?: ExportCommandDeps;
+  readonly apiTransformer?: Transformer;
 };
 
 function buildDeps(env: ApiEnv): WebhookDeps {
@@ -55,6 +58,10 @@ export async function handleWebhook(
     cachedBotInfo = bot.botInfo;
   }
 
+  if (options?.apiTransformer) {
+    bot.api.config.use(options.apiTransformer);
+  }
+
   const deps = options?.deps ?? buildDeps(env);
   registerAddCommand(bot, deps);
   registerExportCommand(bot, env, options);
@@ -85,14 +92,14 @@ function registerAddCommand(bot: Bot, deps: WebhookDeps): void {
       return;
     }
 
-    const templateResult = await deps.templateRepo.findDefault();
+    const templateResult = await resolveTemplate(deps.userRepo, deps.templateRepo, from.id);
     if (templateResult.isErr()) {
       console.error({ event: "template_lookup_failed", error: templateResult.error.message, userId: from.id });
       await ctx.reply("Something went wrong. Please try again later.");
       return;
     }
     if (!templateResult.value) {
-      console.error({ event: "no_default_template", userId: from.id });
+      console.error({ event: "no_active_template", userId: from.id });
       await ctx.reply("No active card template configured. Please contact the admin.");
       return;
     }
@@ -149,14 +156,14 @@ function registerAddCommand(bot: Bot, deps: WebhookDeps): void {
       return;
     }
 
-    const templateResult = await deps.templateRepo.findDefault();
+    const templateResult = await resolveTemplate(deps.userRepo, deps.templateRepo, from.id);
     if (templateResult.isErr()) {
       console.error({ event: "template_lookup_failed", error: templateResult.error.message, userId: from.id });
       await ctx.reply("Something went wrong. Please try again later.");
       return;
     }
     if (!templateResult.value) {
-      console.error({ event: "no_default_template", userId: from.id });
+      console.error({ event: "no_active_template", userId: from.id });
       await ctx.reply("No active card template configured. Please contact the admin.");
       return;
     }

--- a/workers/api/adapters/telegram_webhook_test.ts
+++ b/workers/api/adapters/telegram_webhook_test.ts
@@ -1,7 +1,13 @@
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
-import { handleWebhook } from "./telegram_webhook.ts";
+import { errAsync, okAsync } from "neverthrow";
+import type { Transformer } from "grammy";
+import { handleWebhook, type WebhookDeps } from "./telegram_webhook.ts";
 import { makeTelegramUpdate, mockApiEnv, mockBotInfo } from "../test_helpers.ts";
+import type { CardTemplate } from "../../shared/domain/mod.ts";
+import type { Card } from "../../shared/domain/card.ts";
+import type { NewSubmission, Submission } from "../../shared/domain/submission.ts";
+import type { User } from "../../shared/domain/user.ts";
 
 function makeReq(body: Record<string, unknown>, secretToken = "test-webhook-secret"): Request {
   return new Request("http://localhost/webhook", {
@@ -13,6 +19,125 @@ function makeReq(body: Record<string, unknown>, secretToken = "test-webhook-secr
     body: JSON.stringify(body),
   });
 }
+
+function makeAddUpdate(word: string): Record<string, unknown> {
+  return makeTelegramUpdate({
+    message: {
+      message_id: 2,
+      from: { id: 12345, is_bot: false, first_name: "Test" },
+      chat: { id: 12345, type: "private" },
+      date: 1234567890,
+      text: `/add ${word}`,
+      entities: [{ offset: 0, length: 4, type: "bot_command" }],
+    },
+  });
+}
+
+function makePlainTextUpdate(text: string): Record<string, unknown> {
+  return makeTelegramUpdate({
+    message: {
+      message_id: 3,
+      from: { id: 12345, is_bot: false, first_name: "Test" },
+      chat: { id: 12345, type: "private" },
+      date: 1234567890,
+      text,
+    },
+  });
+}
+
+const defaultTemplate: CardTemplate = {
+  id: 1,
+  name: "Default",
+  promptTemplate: "...",
+  responseJsonSchema: "{}",
+  ankiNoteType: "Basic",
+  ankiFieldsMapping: "{}",
+  isActive: true,
+  createdAt: "2024-01-01",
+};
+
+const defaultUser: User = {
+  telegramId: 12345,
+  firstName: "Test",
+  languageCode: null,
+  activeTemplateId: null,
+  createdAt: "2024-01-01",
+};
+
+const defaultCard: Card = {
+  id: 1,
+  submissionId: 1,
+  word: "word",
+  sentence: "",
+  status: "pending",
+  llmResponseJson: null,
+  audioR2Key: null,
+  errorMessage: null,
+  createdAt: "2024-01-01",
+  updatedAt: "2024-01-01",
+};
+
+const defaultSubmission: Submission = {
+  id: 1,
+  userId: 12345,
+  templateId: 1,
+  chatId: "12345",
+  messageId: "1",
+  status: "pending",
+  errorMessage: null,
+  createdAt: "2024-01-01",
+  updatedAt: "2024-01-01",
+};
+
+function makeTestDeps(overrides?: Partial<WebhookDeps>): WebhookDeps {
+  return {
+    userRepo: {
+      upsert: () => okAsync(defaultUser),
+      findByTelegramId: () => okAsync(null),
+      updateActiveTemplate: () => okAsync(defaultUser),
+    },
+    cardRepo: {
+      findById: () => okAsync(null),
+      findBySubmissionId: () => okAsync([]),
+      findActiveByUserIdAndWord: () => okAsync(null),
+      create: () => okAsync(defaultCard),
+      updateStatus: () => okAsync(defaultCard),
+      findReadyByUserId: () => okAsync([]),
+      markExported: () => okAsync(undefined),
+    },
+    submissionRepo: {
+      findById: () => okAsync(null),
+      create: () => okAsync(defaultSubmission),
+      updateStatus: () => okAsync(defaultSubmission),
+    },
+    queue: { send: () => okAsync(undefined) },
+    templateRepo: {
+      findById: () => okAsync(defaultTemplate),
+      findDefault: () => okAsync(defaultTemplate),
+      create: () => okAsync(defaultTemplate),
+    },
+    ...overrides,
+  };
+}
+
+// Mocks Telegram API so ctx.reply/editMessageText don't make real network calls.
+const mockTelegramApi: Transformer = (_prev, method, _payload) => {
+  if (method === "sendMessage") {
+    return Promise.resolve({
+      ok: true,
+      result: {
+        message_id: 42,
+        from: { id: 123, is_bot: true, first_name: "TestBot" },
+        chat: { id: 12345, type: "private" },
+        date: 1234567890,
+        text: "...",
+      },
+      // deno-lint-ignore no-explicit-any
+    }) as any;
+  }
+  // deno-lint-ignore no-explicit-any
+  return Promise.resolve({ ok: true, result: true }) as any;
+};
 
 describe("handleWebhook", () => {
   it("should return 200 for a valid Telegram update", async () => {
@@ -30,5 +155,136 @@ describe("handleWebhook", () => {
       botInfo: mockBotInfo(),
     });
     assertEquals(res.status, 401);
+  });
+
+  describe("/add command — template resolution", () => {
+    it("does not enqueue when template repo returns error", async () => {
+      let queueSendCalled = false;
+      const deps = makeTestDeps({
+        queue: {
+          send: () => {
+            queueSendCalled = true;
+            return okAsync(undefined);
+          },
+        },
+        templateRepo: {
+          findById: () => okAsync(null),
+          findDefault: () => errAsync({ kind: "repository" as const, message: "DB error" }),
+          create: () => okAsync(defaultTemplate),
+        },
+      });
+      const res = await handleWebhook(makeReq(makeAddUpdate("word | context sentence")), mockApiEnv(), {
+        botInfo: mockBotInfo(),
+        deps,
+        apiTransformer: mockTelegramApi,
+      });
+      assertEquals(res.status, 200);
+      assertEquals(queueSendCalled, false);
+    });
+
+    it("does not enqueue when no active template exists", async () => {
+      let queueSendCalled = false;
+      const deps = makeTestDeps({
+        queue: {
+          send: () => {
+            queueSendCalled = true;
+            return okAsync(undefined);
+          },
+        },
+        templateRepo: {
+          findById: () => okAsync(null),
+          findDefault: () => okAsync(null),
+          create: () => okAsync(defaultTemplate),
+        },
+      });
+      const res = await handleWebhook(makeReq(makeAddUpdate("word | context sentence")), mockApiEnv(), {
+        botInfo: mockBotInfo(),
+        deps,
+        apiTransformer: mockTelegramApi,
+      });
+      assertEquals(res.status, 200);
+      assertEquals(queueSendCalled, false);
+    });
+
+    it("enqueues with the user's activeTemplateId when set", async () => {
+      let capturedTemplateId: number | undefined;
+      const deps = makeTestDeps({
+        userRepo: {
+          upsert: () => okAsync(defaultUser),
+          findByTelegramId: () => okAsync({ ...defaultUser, activeTemplateId: 5 }),
+          updateActiveTemplate: () => okAsync(defaultUser),
+        },
+        templateRepo: {
+          findById: (id) => okAsync({ ...defaultTemplate, id }),
+          findDefault: () => okAsync(defaultTemplate),
+          create: () => okAsync(defaultTemplate),
+        },
+        submissionRepo: {
+          findById: () => okAsync(null),
+          create: (sub: NewSubmission) => {
+            capturedTemplateId = sub.templateId;
+            return okAsync({ ...defaultSubmission, templateId: sub.templateId });
+          },
+          updateStatus: () => okAsync(defaultSubmission),
+        },
+        queue: { send: () => okAsync(undefined) },
+      });
+      await handleWebhook(makeReq(makeAddUpdate("word | context sentence")), mockApiEnv(), {
+        botInfo: mockBotInfo(),
+        deps,
+        apiTransformer: mockTelegramApi,
+      });
+      assertEquals(capturedTemplateId, 5);
+    });
+  });
+
+  describe("plain text message — template resolution", () => {
+    it("does not enqueue when template repo returns error", async () => {
+      let queueSendCalled = false;
+      const deps = makeTestDeps({
+        queue: {
+          send: () => {
+            queueSendCalled = true;
+            return okAsync(undefined);
+          },
+        },
+        templateRepo: {
+          findById: () => okAsync(null),
+          findDefault: () => errAsync({ kind: "repository" as const, message: "DB error" }),
+          create: () => okAsync(defaultTemplate),
+        },
+      });
+      const res = await handleWebhook(makeReq(makePlainTextUpdate("word | context sentence")), mockApiEnv(), {
+        botInfo: mockBotInfo(),
+        deps,
+        apiTransformer: mockTelegramApi,
+      });
+      assertEquals(res.status, 200);
+      assertEquals(queueSendCalled, false);
+    });
+
+    it("does not enqueue when no active template exists", async () => {
+      let queueSendCalled = false;
+      const deps = makeTestDeps({
+        queue: {
+          send: () => {
+            queueSendCalled = true;
+            return okAsync(undefined);
+          },
+        },
+        templateRepo: {
+          findById: () => okAsync(null),
+          findDefault: () => okAsync(null),
+          create: () => okAsync(defaultTemplate),
+        },
+      });
+      const res = await handleWebhook(makeReq(makePlainTextUpdate("word | context sentence")), mockApiEnv(), {
+        botInfo: mockBotInfo(),
+        deps,
+        apiTransformer: mockTelegramApi,
+      });
+      assertEquals(res.status, 200);
+      assertEquals(queueSendCalled, false);
+    });
   });
 });

--- a/workers/api/services/resolve_template.ts
+++ b/workers/api/services/resolve_template.ts
@@ -1,0 +1,19 @@
+import type { ResultAsync } from "neverthrow";
+import type { CardTemplate } from "../../shared/domain/mod.ts";
+import type { RepositoryError } from "../../shared/domain/errors.ts";
+import type { TemplateRepositoryPort } from "../../shared/ports/template_repository.ts";
+import type { UserRepositoryPort } from "../../shared/ports/user_repository.ts";
+
+export function resolveTemplate(
+  userRepo: UserRepositoryPort,
+  templateRepo: TemplateRepositoryPort,
+  telegramId: number,
+): ResultAsync<CardTemplate | null, RepositoryError> {
+  return userRepo.findByTelegramId(telegramId).andThen((user) => {
+    const templateId = user?.activeTemplateId ?? null;
+    if (templateId !== null) {
+      return templateRepo.findById(templateId);
+    }
+    return templateRepo.findDefault();
+  });
+}

--- a/workers/api/services/resolve_template_test.ts
+++ b/workers/api/services/resolve_template_test.ts
@@ -1,0 +1,144 @@
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { errAsync, okAsync } from "neverthrow";
+import type { CardTemplate } from "../../shared/domain/mod.ts";
+import type { User } from "../../shared/domain/user.ts";
+import { resolveTemplate } from "./resolve_template.ts";
+
+function makeTemplate(id: number): CardTemplate {
+  return {
+    id,
+    name: "Test Template",
+    promptTemplate: "...",
+    responseJsonSchema: "{}",
+    ankiNoteType: "Basic",
+    ankiFieldsMapping: "{}",
+    isActive: true,
+    createdAt: "2024-01-01",
+  };
+}
+
+function makeUser(activeTemplateId: number | null = null): User {
+  return { telegramId: 12345, firstName: "Test", languageCode: null, activeTemplateId, createdAt: "2024-01-01" };
+}
+
+const repoErr = { kind: "repository" as const, message: "DB error" };
+
+describe("resolveTemplate", () => {
+  it("falls back to findDefault when user is not found", async () => {
+    const defaultTpl = makeTemplate(1);
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(null),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => okAsync(null), findDefault: () => okAsync(defaultTpl), create: () => okAsync(defaultTpl) },
+      12345,
+    );
+    assertEquals(result._unsafeUnwrap(), defaultTpl);
+  });
+
+  it("falls back to findDefault when user has no activeTemplateId", async () => {
+    const defaultTpl = makeTemplate(1);
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(makeUser(null)),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => okAsync(null), findDefault: () => okAsync(defaultTpl), create: () => okAsync(defaultTpl) },
+      12345,
+    );
+    assertEquals(result._unsafeUnwrap(), defaultTpl);
+  });
+
+  it("uses findById with user activeTemplateId when set", async () => {
+    const userTpl = makeTemplate(5);
+    let findByIdCalledWith: number | undefined;
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(makeUser(5)),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      {
+        findById: (id: number) => {
+          findByIdCalledWith = id;
+          return okAsync(userTpl);
+        },
+        findDefault: () => okAsync(null),
+        create: () => okAsync(userTpl),
+      },
+      12345,
+    );
+    assertEquals(result._unsafeUnwrap(), userTpl);
+    assertEquals(findByIdCalledWith, 5);
+  });
+
+  it("returns null when findDefault returns null", async () => {
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(null),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => okAsync(null), findDefault: () => okAsync(null), create: () => okAsync(makeTemplate(1)) },
+      12345,
+    );
+    assertEquals(result._unsafeUnwrap(), null);
+  });
+
+  it("returns null when user activeTemplateId points to a non-existent template", async () => {
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(makeUser(99)),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => okAsync(null), findDefault: () => okAsync(null), create: () => okAsync(makeTemplate(1)) },
+      12345,
+    );
+    assertEquals(result._unsafeUnwrap(), null);
+  });
+
+  it("propagates userRepo error", async () => {
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => errAsync(repoErr),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => okAsync(null), findDefault: () => okAsync(null), create: () => okAsync(makeTemplate(1)) },
+      12345,
+    );
+    assertEquals(result.isErr(), true);
+    assertEquals(result._unsafeUnwrapErr(), repoErr);
+  });
+
+  it("propagates findDefault error", async () => {
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(null),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => okAsync(null), findDefault: () => errAsync(repoErr), create: () => okAsync(makeTemplate(1)) },
+      12345,
+    );
+    assertEquals(result.isErr(), true);
+  });
+
+  it("propagates findById error", async () => {
+    const result = await resolveTemplate(
+      {
+        upsert: () => okAsync(makeUser()),
+        findByTelegramId: () => okAsync(makeUser(5)),
+        updateActiveTemplate: () => okAsync(makeUser()),
+      },
+      { findById: () => errAsync(repoErr), findDefault: () => okAsync(null), create: () => okAsync(makeTemplate(1)) },
+      12345,
+    );
+    assertEquals(result.isErr(), true);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaced hardcoded `DEFAULT_TEMPLATE_ID = 1` with dynamic lookup via `templateRepo.findDefault()` in the Telegram webhook adapter
- Added `findDefault()` method to `TemplateRepositoryPort` and its D1 implementation, querying the first active template
- Extended `WebhookDeps` to include `templateRepo` for dependency injection

Resolves #44

## Test plan

- [ ] Verify `/add` command resolves the default template from DB instead of using hardcoded ID
- [ ] Verify error handling when no active template exists
- [ ] Run `deno task check` to confirm type-check, lint, and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)